### PR TITLE
Feature/build from source

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,15 +12,20 @@ depends=(
 makedepends=(
   "go"
 )
-source=("https://github.com/quorumcontrol/$pkgname/archive/${pkgver//_/-}.tar.gz")
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/quorumcontrol/$pkgname/archive/${pkgver//_/-}.tar.gz")
 sha256sums=("59558367e31a92f4b9fb77d2f9570c241fda3d8b1f1a8b5133b1c376b24d4587")
 
+build() {
+  export GOPATH="$srcdir"/gopath
+  cd "$srcdir/$pkgname-$pkgver"
+  EXTRA_GOFLAGS="-modcacherw -gcflags all=-trimpath=${PWD} -asmflags all=-trimpath=${PWD}" \
+    LDFLAGS="-linkmode external -extldflags \"${LDFLAGS}\"" \
+    make VERSION=$pkgver DESTDIR="$pkgdir" PREFIX="/usr" build
+}
+
 package() {
-  cd "$srcdir/"
-  bindir="$pkgdir/usr/bin/"
-  mkdir -p $bindir
-  cp dgit $bindir
-  cp git-remote-dgit $bindir
+  cd "$srcdir/$pkgname-$pkgver"
+  make VERSION=$pkgver DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
 # vim:set ts=2 sw=2 et:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer:  <dev@quorumcontrol.com>
-pkgname=dgit
+pkgname=git-dg
 pkgver="v0.0.15_alpha"
 pkgrel=1
 pkgdesc="Decentralized git remotes"
 arch=('x86_64')
 url="https://dgit.dev"
 license=('MIT')
-provides=('dgit')
+provides=('git-dg')
 depends=(
   "git"
 )

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,8 +9,11 @@ license=('MIT')
 depends=(
   "git"
 )
-source=("https://github.com/quorumcontrol/$pkgname/releases/download/${pkgver//_/-}/$pkgname-Linux-$arch.tar.gz")
-sha256sums=('c57d1416c8841d6cf198f375da57962e5c0ece81d087d1e6a537e67ae98d8ad9')
+makedepends=(
+  "go"
+)
+source=("https://github.com/quorumcontrol/$pkgname/archive/${pkgver//_/-}.tar.gz")
+sha256sums=("59558367e31a92f4b9fb77d2f9570c241fda3d8b1f1a8b5133b1c376b24d4587")
 
 package() {
   cd "$srcdir/"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer:  <dev@quorumcontrol.com>
 pkgname=dgit
-pkgver="v0.0.15_alpha"
+pkgver="v0.0.15-alpha"
 pkgrel=1
 pkgdesc="Decentralized git remotes"
 arch=('x86_64')
@@ -12,7 +12,7 @@ depends=(
 makedepends=(
   "go"
 )
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/quorumcontrol/$pkgname/archive/${pkgver//_/-}.tar.gz")
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/quorumcontrol/$pkgname/archive/$pkgver.tar.gz")
 sha256sums=("59558367e31a92f4b9fb77d2f9570c241fda3d8b1f1a8b5133b1c376b24d4587")
 
 build() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer:  <dev@quorumcontrol.com>
 pkgname=dgit
-pkgver="v0.0.15-alpha"
+pkgver="v0.0.15_alpha"
 pkgrel=1
 pkgdesc="Decentralized git remotes"
 arch=('x86_64')
@@ -12,20 +12,20 @@ depends=(
 makedepends=(
   "go"
 )
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/quorumcontrol/$pkgname/archive/$pkgver.tar.gz")
+source=("${pkgname}-${pkgver//_/-}.tar.gz::https://github.com/quorumcontrol/$pkgname/archive/${pkgver//_/-}.tar.gz")
 sha256sums=("59558367e31a92f4b9fb77d2f9570c241fda3d8b1f1a8b5133b1c376b24d4587")
 
 build() {
   export GOPATH="$srcdir"/gopath
-  cd "$srcdir/$pkgname-$pkgver"
+  cd "$srcdir/$pkgname-${pkgver//_/-}"
   EXTRA_GOFLAGS="-modcacherw -gcflags all=-trimpath=${PWD} -asmflags all=-trimpath=${PWD}" \
     LDFLAGS="-linkmode external -extldflags \"${LDFLAGS}\"" \
-    make VERSION="$pkgver" DESTDIR="$pkgdir" PREFIX="/usr" build
+    make VERSION=${pkgver//_/-} DESTDIR="$pkgdir" PREFIX="/usr" build
 }
 
 package() {
-  cd "$srcdir/$pkgname-$pkgver"
-  make VERSION="$pkgver" DESTDIR="$pkgdir" PREFIX="/usr" install
+  cd "$srcdir/$pkgname-${pkgver//_/-}"
+  make VERSION=${pkgver//_/-} DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
 # vim:set ts=2 sw=2 et:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,6 +6,7 @@ pkgdesc="Decentralized git remotes"
 arch=('x86_64')
 url="https://dgit.dev"
 license=('MIT')
+provides=('dgit')
 depends=(
   "git"
 )

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer:  <dev@quorumcontrol.com>
-pkgname=git-dg
+pkgname="decentragit"
 pkgver="v0.0.15_alpha"
 pkgrel=1
 pkgdesc="Decentralized git remotes"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,12 +20,12 @@ build() {
   cd "$srcdir/$pkgname-$pkgver"
   EXTRA_GOFLAGS="-modcacherw -gcflags all=-trimpath=${PWD} -asmflags all=-trimpath=${PWD}" \
     LDFLAGS="-linkmode external -extldflags \"${LDFLAGS}\"" \
-    make VERSION=$pkgver DESTDIR="$pkgdir" PREFIX="/usr" build
+    make VERSION="$pkgver" DESTDIR="$pkgdir" PREFIX="/usr" build
 }
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"
-  make VERSION=$pkgver DESTDIR="$pkgdir" PREFIX=/usr install
+  make VERSION="$pkgver" DESTDIR="$pkgdir" PREFIX="/usr" install
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
The current master "works" in order to install dgit on an arch system, but the package build script won't be accepted into the Arch User Repository (AUR) unless the package is built directly from source (security measure). 

This updates the build script to install from source so it can be accepted into the AUR. Once the script is accepted, end users will be able to install dgit with a single command. This is in draft status because it depends on https://github.com/quorumcontrol/dgit/pull/70